### PR TITLE
docs(standalone-cli): refine PRD and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,86 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - Root: `Cargo.toml` (workspace, edition 2021), `.gitignore`, `PRD.md`.
 - Core lib `crates/ditox-core/`: domain types; `Store` + SQLite backend; clipboard adapters; SQL migrations in `migrations/`; file‑backed blobs under `objects/aa/bb/<sha256>`; image groundwork via `ClipKind::Image` and `ImageMeta`.
 - CLI `crates/ditox-cli/`: commands `add`, `list`, `search`, `copy`, `favorite`, `migrate`, `doctor`.
 - Tests live under `crates/*/tests/`.
 
 ## Build, Test, and Development Commands
-- Build all: `cargo build`
-- Build CLI only: `cargo build -p ditox-cli`
-- Run CLI: `cargo run -p ditox-cli -- list`
-- Format: `cargo fmt --all`
-- Lint: `cargo clippy --all-targets -- -D warnings`
-- Test: `cargo test --all`
+
+- Build all: `cargo build` — workspace build.
+- CLI only: `cargo build -p ditox-cli`.
+- Run CLI: `cargo run -p ditox-cli -- list` (example command).
+- Format: `cargo fmt --all`.
+- Lint: `cargo clippy --all-targets -- -D warnings` (do not use `cargo clippy -q -p ditox-cli -- -D`).
+- Test: `cargo test --all`.
 - Migrations (SQLite):
-  - Status: `cargo run -p ditox-cli -- migrate --status`
-  - Apply with backup: `cargo run -p ditox-cli -- migrate --backup`
-  - Useful flags: `--db <path>`, `--auto-migrate=false`
+    - Status: `cargo run -p ditox-cli -- migrate --status`
+    - Apply with backup: `cargo run -p ditox-cli -- migrate --backup`
+    - Useful flags: `--db <path>`, `--auto-migrate=false`
 
 ## Coding Style & Naming Conventions
-- rustfmt defaults; keep Clippy at zero warnings.
-- Modules/files `snake_case`; types/enums `CamelCase`; functions/fields `snake_case`.
+
+- Use `rustfmt` defaults; keep Clippy at zero warnings.
+- Names: modules/files `snake_case`; types/enums `CamelCase`; functions/fields `snake_case`.
 - Errors: CLI uses `anyhow`; core uses `thiserror` + `Result`; avoid `unwrap()`/`expect()` in library code.
 - Migrations: `NNNN_description.sql` (4‑digit, ascending); one concern per file.
 
 ## Testing Guidelines
+
 - Prefer black‑box CLI tests with `assert_cmd` + `predicates` in `crates/ditox-cli/tests/`.
 - For DB tests, create a temp SQLite file per test and clean up.
 - Add doc tests for examples in public APIs.
 - Run all tests: `cargo test --all`.
 
 ## Commit & Pull Request Guidelines
-- Conventional commits (e.g., `feat(core): sqlite FTS search`, `fix(cli): handle empty stdin`).
-- PRs must describe intent, link issues, list commands run, and note DB migrations + CLI flags touched.
-- Before opening: run fmt, clippy, tests, and `migrate --status`.
+
+- Conventional commits (examples): `feat(core): sqlite FTS search`, `fix(cli): handle empty stdin`.
+- PRs: describe intent, link issues, list commands run, and note DB migrations + CLI flags touched; include relevant output/screenshots for UX‑affecting changes.
 
 ## Security & Configuration Tips
+
 - Clipboard data is sensitive—avoid logging secrets; redact in examples/tests.
 - Default DB path follows XDG; review retention/pruning before enabling sync (future work).
 - v0.1.0 targets Linux (X11/Wayland via `arboard`); other OS adapters land later.
 
 ## Agent‑Specific Notes
-- Scope: this file applies to the entire repo for AI assistants.
-- Important: never run `cargo clippy -q -p ditox-cli -- -D` (can hang). Use `cargo clippy --all-targets -- -D warnings` instead.
+
+- Scope: this file applies to the entire repository for AI assistants.
 - Keep changes minimal and focused; update docs when touching migrations or CLI flags.
 
+## Git Worktrees
+
+- Location: use `./.worktrees/` for all task‑specific checkouts. Ensure it exists with `mkdir -p ./.worktrees` before creating any worktree.
+- Branch naming: derive from the task type and a short, kebab‑case slug of the request. Use Conventional Commit types for the prefix:
+    - Features: `feat/<slug>` (default if unspecified)
+    - Fixes: `fix/<slug>`
+    - Docs: `docs/<slug>`
+    - Refactors/Chores/Perf/Tests: `refactor/<slug>` or `chore/<slug>` or `perf/<slug>` or `test/<slug>` as appropriate
+- Worktree directory name: mirror the branch name but replace `/` with `__` to avoid nested folders; e.g., branch `feat/image-deduping` → dir `./.worktrees/feat__image-deduping`.
+- Create a new worktree from `origin/main`:
+    - `git fetch origin`
+    - `BRANCH="feat/<slug>"; DIR=".worktrees/${BRANCH//\//__}"`
+    - `git worktree add -b "$BRANCH" "$DIR" origin/main`
+- Use the worktree:
+    - `cd "$DIR"`
+    - Implement changes; run builds/tests here, not in the main checkout.
+- Push and open PR:
+    - `git push -u origin "$BRANCH"`
+    - Open a PR from `$BRANCH` into `main` (follow Conventional Commits in commit messages).
+- Keep in sync with `main` while working:
+    - `git fetch origin && git rebase origin/main` (inside the worktree). Avoid merge commits in feature branches.
+- Clean up after merge:
+    - `cd -` (leave the worktree dir)
+    - `git worktree remove "$DIR"` (use `--force` only if necessary)
+    - `git branch -d "$BRANCH"`
+    - `git push origin --delete "$BRANCH"` (if the remote branch was pushed)
+    - `git worktree prune`
+- Rules of thumb:
+    - One worktree per user‑visible task/feature; name slugs short and specific (e.g., `qr-decode`, `fts-search`, `migrate-status-ui`).
+    - Do not commit directly to `main`; always work in a worktree branch and open a PR.
+    - Never place other Git repos under `./.worktrees/`; it is exclusively for worktrees.
+    - If you must switch tasks, create a new branch/worktree rather than reusing an existing one.
+
+Note: Avoid `cargo clippy -q -p ditox-cli -- -D` (can hang). Prefer `cargo clippy --all-targets -- -D warnings`.

--- a/standalone-cli-PRD.md
+++ b/standalone-cli-PRD.md
@@ -36,22 +36,22 @@ Ship a “standalone” Ditox experience where the `ditox` CLI/TUI runs with an 
 Defaults target simplicity. Flags are additive and remain backward compatible.
 
 - `ditox` (alias: `ditox tui`)
-  - Starts TUI.
-  - Default capture mode: `--daemon=managed` (embedded watcher).
-  - New flags:
-    - `--daemon <managed|external|off>` (default `managed`)
-      - `managed`: spawn embedded watcher inside the same process.
-      - `external`: do not spawn; expect external `ditox-clipd` or none.
-      - `off`: do not capture; view‑only.
-    - `--daemon-sample <dur>` sampling interval (default: `200ms`).
-    - `--daemon-images <on|off>` (default: `on`).
-    - `--no-auto-migrate` (mirrors existing, passthrough to store).
-  - TUI hotkeys (visible in help):
-    - `p`: pause/resume capture.
-    - `D`: toggle image capture on/off for session.
+    - Starts TUI.
+    - Default capture mode: `--daemon=managed` (embedded watcher).
+    - New flags:
+        - `--daemon <managed|external|off>` (default `managed`)
+            - `managed`: spawn embedded watcher inside the same process.
+            - `external`: do not spawn; expect external `ditox-clipd` or none.
+            - `off`: do not capture; view‑only.
+        - `--daemon-sample <dur>` sampling interval (default: `200ms`).
+        - `--daemon-images <on|off>` (default: `on`).
+        - `--no-auto-migrate` (mirrors existing, passthrough to store).
+    - TUI hotkeys (visible in help):
+        - `p`: pause/resume capture.
+        - `D`: toggle image capture on/off for session.
 
 - `ditox doctor`
-  - Reports “Managed Daemon: active|paused|off”, backend (X11/Wayland), sample interval, lock owner (pid), and conflict detection (external daemon present: yes/no).
+    - Reports “Managed Daemon: active|paused|off”, backend (X11/Wayland), sample interval, lock owner (pid), and conflict detection (external daemon present: yes/no).
 
 - `ditox daemon …` (existing external daemon remains; docs point casual users to just `ditox`).
 
@@ -62,29 +62,29 @@ Defaults target simplicity. Flags are additive and remain backward compatible.
 - Embed a clipboard watcher (“managed daemon”) into `ditox-cli` when in TUI mode.
 - Watcher runs in the same process as the TUI and writes to the same SQLite store via `ditox-core::Store` with identical semantics to `ditox-clipd`.
 - On startup:
-  1) Detect external daemon (pidfile/lockfile probe).
-  2) If found and `--daemon=managed`, switch to `external` mode silently (no embedded watcher) to avoid double capture.
-  3) If none and `--daemon=managed`, spawn a background task (Tokio) that:
-     - polls clipboard at configured interval;
-     - deduplicates consecutive identical content (hash, timestamp);
-     - persists entries via the store; supports images behind feature gate.
-  4) When TUI exits, task shuts down gracefully.
+    1. Detect external daemon (pidfile/lockfile probe).
+    2. If found and `--daemon=managed`, switch to `external` mode silently (no embedded watcher) to avoid double capture.
+    3. If none and `--daemon=managed`, spawn a background task (Tokio) that:
+        - polls clipboard at configured interval;
+        - deduplicates consecutive identical content (hash, timestamp);
+        - persists entries via the store; supports images behind feature gate.
+    4. When TUI exits, task shuts down gracefully.
 
 ### Process/Task Model
 
 - Single OS process, multiple async tasks:
-  - UI task (ratatui + crossterm) — existing.
-  - Managed watcher task (Tokio) — new.
-  - Optional: background maintenance (pruning, thumbs) — reused from existing paths.
+    - UI task (ratatui + crossterm) — existing.
+    - Managed watcher task (Tokio) — new.
+    - Optional: background maintenance (pruning, thumbs) — reused from existing paths.
 - Runtime: enable `tokio` for the CLI by default (we already use it behind `libsql`). UI remains synchronous with a small bridge to spawn tasks.
 
 ### Concurrency & Safety
 
 - Database access: reuse `ditox-core` connection management; one writer task (watcher) + UI readers.
 - Single‑instance capture guard:
-  - File lock in XDG state dir (e.g., `~/.local/state/ditox/managed-daemon.lock`) containing pid + start time.
-  - If lock exists and pid alive → assume external/other capture active; do not start embedded watcher.
-  - If stale lock → clean up and continue.
+    - File lock in XDG state dir (e.g., `~/.local/state/ditox/managed-daemon.lock`) containing pid + start time.
+    - If lock exists and pid alive → assume external/other capture active; do not start embedded watcher.
+    - If stale lock → clean up and continue.
 
 ### Clipboard Backends
 
@@ -99,10 +99,10 @@ Defaults target simplicity. Flags are additive and remain backward compatible.
 ### Configuration
 
 - Use existing config file (`~/.config/ditox/settings.toml`). New keys:
-  - `[daemon]
-     mode = "managed" | "external" | "off"
-     sample = "200ms"
-     images = true`
+    - `[daemon]
+ mode = "managed" | "external" | "off"
+ sample = "200ms"
+ images = true`
 - CLI flags override config, config overrides defaults.
 
 ### Compatibility & Coexistence
@@ -114,17 +114,21 @@ Defaults target simplicity. Flags are additive and remain backward compatible.
 ## Migration / Refactor Plan
 
 Phase 0 (prep)
+
 - Extract reusable watcher logic from `ditox-clipd` into a new internal module (`crates/ditox-cli/src/managed_daemon.rs`) by copy‑move first, then deduplicate with `ditox-clipd` in a follow‑up.
 
 Phase 1 (MVP)
+
 - Add managed daemon to CLI TUI with defaults above.
 - Add locking, sampling, image toggle, and pause/resume in TUI.
 - Update `doctor` and docs.
 
 Phase 2 (Consolidation)
+
 - Refactor `ditox-clipd` into a small bin that calls a new `clipd-lib` (shared between CLI managed daemon and external daemon) to eliminate duplication.
 
 Phase 3 (Optional)
+
 - Provide `--detach` to keep the managed daemon running after TUI exit (off by default; not in MVP scope).
 
 ## Security & Privacy
@@ -165,10 +169,10 @@ Phase 3 (Optional)
 
 ## Open Questions
 
-1) Should `managed` be the default for `ditox tui` only, or for any `ditox` command that keeps the process running? (Proposal: TUI only.)
-2) Do we want a keybind to toggle between `external` and `managed` live? (Likely no for MVP.)
-3) Should we support `--detach` to keep capture after TUI exit? (Out of MVP, possibly Phase 3.)
-4) Where to host the shared daemon code long‑term: inside `ditox-core` or a new `clipd-lib` crate? (Proposal: `clipd-lib`.)
+1. Should `managed` be the default for `ditox tui` only, or for any `ditox` command that keeps the process running? (Proposal: TUI only.)
+2. Do we want a keybind to toggle between `external` and `managed` live? (Likely no for MVP.)
+3. Should we support `--detach` to keep capture after TUI exit? (Out of MVP, possibly Phase 3.)
+4. Where to host the shared daemon code long‑term: inside `ditox-core` or a new `clipd-lib` crate? (Proposal: `clipd-lib`.)
 
 ## Acceptance Criteria
 
@@ -178,3 +182,226 @@ Phase 3 (Optional)
 - `doctor` shows correct managed daemon status and environment details.
 - No regression to list/search/copy/image flows; tests pass; CI green.
 
+# Ditox Standalone TUI and Managed Capture — Implementation Notes
+
+This document captures everything we added for the standalone TUI picker, the embedded managed capture, and the customization system so it can be re‑implemented or ported cleanly.
+
+## Goals
+
+- Fast, single‑binary interactive picker (no separate server needed).
+- Optional embedded capture daemon with pause/images control and single‑instance locking.
+- Customizable TUI (themes, glyphs, layouts; ASCII/no‑color fallbacks).
+- Debounced auto‑refresh, selection preservation, and “New” badges.
+- Compatible with existing local SQLite and optional remote libsql/Turso.
+
+## High‑Level Architecture
+
+- Entry: `crates/ditox-cli/src/main.rs`
+    - Parses CLI flags (`Pick` command) and prepares a “lazy” store.
+    - Optionally starts an embedded capture daemon (managed mode) if no external clipd is detected.
+    - Passes capture status + settings to the picker (`picker::run_picker_default`).
+- TUI: `crates/ditox-cli/src/picker.rs`
+    - Draws frames with ratatui (list, title, footer, help overlay).
+    - Reads theme, glyphs, layout packs at startup.
+    - Debounced refresh + search + selection restore + “New” badges.
+- Customization helpers: `crates/ditox-cli/src/theme.rs`
+    - Theme loader (`load_tui_theme`) with color caps and border types.
+    - Glyph packs (`load_glyphs`) and layout packs (`load_layout`).
+- Embedded capture: `crates/ditox-cli/src/managed_daemon.rs`
+    - Managed watcher thread, lockfile handling, pause/images toggles.
+- Optional tray (feature `tray`): `crates/ditox-cli/src/tray.rs`
+    - Pause/Images/QUIT menu wired to managed control.
+
+## Modules and Key Types
+
+- `picker.rs`
+    - `run_picker_default`, `run_picker_with` (TUI core loop)
+    - `CaptureMode` (Managed | External | Off)
+    - `CaptureStatus { mode, managed: Option<ManagedControl> }`
+    - `EventSource`/`RealEventSource` for easy testing
+    - Helper: `selected_id(...)` to preserve cursor selection
+- `managed_daemon.rs`
+    - `DaemonConfig { sample: Duration, images: bool, image_cap_bytes: Option<usize> }`
+    - `ManagedHandle` (lifetime + lock cleanup) and `ManagedControl` (pause/images/sample getters + toggles)
+    - `try_create_lock()` and `detect_external_clipd()`
+- `theme.rs`
+    - `Caps { color_depth, unicode, no_color }` (`detect_caps`)
+    - `TuiTheme { ... colors ... border_type }` and `load_tui_theme()`
+    - `Glyphs` + `load_glyphs()` (ASCII/Unicode/built‑ins + user packs)
+    - `LayoutPack` + `load_layout()` (border styles, line heights, templates)
+
+## CLI Surface (Pick)
+
+File: `crates/ditox-cli/src/main.rs`
+
+- Managed capture and refresh
+    - `--daemon {managed|external|off}` (default: managed)
+    - `--daemon-sample <duration>` (e.g., 200ms, 1s)
+    - `--daemon-images {true|false}`
+    - `--no-daemon` (bypass daemon IPC)
+    - `--refresh-ms <u64>` (debounced auto‑refresh interval, overrides config)
+- Backend and filters
+    - `--remote` (force libsql/Turso; disables daemon)
+    - `--tag <string>` (filter by tag)
+    - `--favorites`, `--images`
+- TUI customization
+    - `--theme <name|path>`; `--ascii`; `--color {auto|always|never}`
+    - Discovery/preview: `--themes`, `--glyphsets`, `--layouts`, `--preview <theme>`, `--dump-caps`
+    - `--glyphs <name|path>`, `--layout <name|path>`
+
+Other commands: `doctor` (prints capture status), `thumbs`, `config`, etc., were preserved.
+
+## Settings (TOML)
+
+File: `crates/ditox-cli/src/config.rs`
+
+- Table `[tui]`
+    - `page_size: Option<usize>` — default 10
+    - `auto_apply_tag_ms: Option<u64>` — auto apply `#tag` after idle typing
+    - `absolute_times: Option<bool>` — show absolute instead of relative
+    - `refresh_ms: Option<u64>` — debounced auto‑refresh interval (default 1500)
+    - `sound_on_new: Option<bool>` — reserved future toggle (default false)
+    - `theme: Option<String>` — name or path (e.g., "dark", or `~/.config/ditox/themes/custom.toml`)
+    - `color: Option<String>` — `auto|always|never`
+    - `box_chars: Option<String>` — `unicode|ascii` (ASCII disables borders)
+    - `alt_screen: Option<bool>` — use alternate screen buffer
+    - `live_reload: Option<bool>` — reserved (no‑op placeholder)
+    - `date_format: Option<String>` — date tokens for absolute mode
+    - `auto_recent_days: Option<u32>` — threshold days for auto → absolute
+    - `glyphs: Option<String>` — name or file path
+    - `layout: Option<String>` — name or file path
+
+- Table `[storage]` remains unchanged (`LocalSqlite`/`Turso`).
+
+## Environment Variables
+
+These supplement CLI/config for fast overrides:
+
+- `DITOX_TUI_THEME` — theme name or path
+- `DITOX_TUI_COLOR` — `auto|always|never`
+- `DITOX_TUI_ASCII` — `1` to force ASCII draw
+- `DITOX_TUI_ALT_SCREEN` — `1|0` to enable/disable alternate screen
+- `DITOX_TUI_DATE_FMT` — date format string
+- `DITOX_TUI_AUTO_DAYS` — integer recent threshold
+- `DITOX_TUI_GLYPHS` — glyph pack name or path
+- `DITOX_TUI_LAYOUT` — layout pack name or path
+
+## Rendering & Theming
+
+- Color/no‑color and Unicode/ASCII detection via `detect_caps()`.
+- Theme (`TuiTheme`) provides:
+    - Title, status, badge, muted, border colors; search match colors; `border_type`.
+- Glyphs (`Glyphs`): favorite on/off, selected/unselected marks, kind icons, `enter_label`.
+- Layout (`LayoutPack`):
+    - Where to draw search bar (top/bottom), item line height (1 or 2),
+    - Optional templating for list title/footer/items/meta/help,
+    - Per‑section borders and a compact pager ("{page}/{page_count}").
+
+## TUI Behavior
+
+- Modes: Normal and Query (`/` toggles). Query text applied live.
+- Tag input: when Query text starts with `#`, auto‑apply tag after `auto_apply_tag_ms` idle.
+- Paging: dynamic rows per page based on viewport height and `list_line_height`.
+- Selection: restored via stable ID on refresh/filter changes (keeps cursor where possible).
+- “New” badges: new IDs get a badge for ~2.5s after appearance.
+- Footer: shows shortcuts (customizable), optional capture status (
+  `managed (N ms, images:on|off, paused|active)` | `external` | `off`).
+- Help overlay: centered modal with multi‑column hotkeys; respects theme/layout/borders.
+
+## Key Bindings (default)
+
+- Navigation: `↑/k`, `↓/j`, `→/l/PgDn`, `←/h/PgUp`, `Home/g`, `End/G`
+- Filter/Search: `/` toggle, `t` apply `#tag`, `r` refresh
+- Favorites/Images: `Tab` favorites toggle, `i` images view toggle
+- Managed capture (when available): `D` images capture toggle, `Ctrl+P` pause/resume
+- Selection & actions: `s` select, `S` clear selection, `Enter` copy, `x` delete, `p` fav/unfav
+- Help/Exit: `?` help, `q` or `Esc` quit
+
+## Embedded Managed Capture
+
+File: `crates/ditox-cli/src/managed_daemon.rs`
+
+- Lockfile: `${state_dir}/managed-daemon.lock`
+    - Linux: stale lock detection via `/proc/<pid>`; removes stale and continues.
+    - Non‑Linux (macOS/Windows): fail fast if a lock exists (prevents double capturers).
+- Sampling loop:
+    - Poll text; trim trailing `\n`; dedupe via recent list; `Store::add` or `touch_last_used`.
+    - Optional image capture (bytes cap check) via `add_image_rgba`.
+- Controls exposed through `ManagedControl`:
+    - `toggle_pause()`, `is_paused()`, `toggle_images()`, `images_on()`, `sample()`.
+- External detection: `config/clipd.json` with TCP connect confirmation.
+
+## Optional Tray (feature `tray`)
+
+File: `crates/ditox-cli/src/tray.rs`
+
+- Menu entries: Pause/Resume, Images on/off, Quit.
+- Hooks into `ManagedControl` if managed capture is active.
+- Small icon builder, optional PNG fallback.
+
+## Backend Policy (Picker)
+
+- If `--remote`: always use libsql/Turso, bypass daemon.
+- Otherwise: local SQLite for picker and managed capture, with DB path:
+    - `[storage.local_sqlite].db_path` or default `${config_dir}/db/ditox.db`.
+- Daemon start policy:
+    - `--daemon` + no external clipd detected → start embedded daemon.
+    - Environment override: `DITOX_DAEMON={managed|external|off}`.
+
+## Diagnostics
+
+- Doctor (`ditox config` / `ditox doctor`): prints capture status and clipboard checks.
+- Errors from TUI copy operations are deferred and printed after exit.
+
+## CI/Policy Notes
+
+- `deny.toml`: allow `"Apache-2.0 WITH LLVM-exception"`.
+- Advisories ignored (tray‑only transitive GTK3/GLib):
+    - RUSTSEC‑2024‑0412/0413/0415/0416/0418/0419/0420, and glib VariantStrIter unsoundness (RUSTSEC‑2024‑0429),
+    - `proc-macro-error` unmaintained (RUSTSEC‑2024‑0370).
+- These are ignored because tray is optional and only used for desktop UI; CLI/core paths are unaffected.
+
+## Re‑Implementation Checklist
+
+1. CLI flags (Pick)
+    - Add to `crates/ditox-cli/src/main.rs` under `Commands::Pick` the flags listed above and the env‑wiring for theme/color/ascii/layout/glyphs.
+2. Managed daemon
+    - Restore `crates/ditox-cli/src/managed_daemon.rs` with lockfile policy and controls.
+    - In `main.rs`, compute effective daemon mode and optionally call `start_managed(...)`.
+3. TUI entry
+    - Call `theme::load_tui_theme()`, `theme::load_glyphs()`, `theme::load_layout()` at the top of `run_picker_with`.
+    - Respect caps: `detect_caps()` → ascii/no‑color fallbacks; apply borders via `border_type` where present.
+4. Picker loop
+    - Add debounced refresh (`refresh_ms`) and `last_key_ts` typing debounce.
+    - Preserve selection via ID (`pending_restore_id` + `selected_id()` helper).
+    - Track `last_ids` + `new_until` to render “New” badges.
+5. Rendering
+    - Use theme colors for: title, list highlight, borders, footer, help overlay, match highlights.
+    - If `layout.*_template` exists, expand placeholders; else render defaults.
+    - Optional pager at bottom‑right of list area using `pager_template`.
+6. Keybindings
+    - Implement bindings listed above; ensure help overlay and footer reflect them.
+7. Backend policy
+    - Build lazy store with remote/local rules; bypass daemon when remote.
+8. Tray (optional)
+    - Guard under `#[cfg(feature = "tray")]` and keep GTK3 dev‑deps out of default build.
+9. Doctor/config outputs
+    - Show capture status; surface errors non‑fatally.
+
+## Test Matrix (manual)
+
+- Linux tty: ASCII and Unicode; color `auto|never|always`.
+- With and without daemon; with external clipd running.
+- `--remote` (libsql) disables daemon and still renders badges.
+- Themes: built‑in `dark` and `high-contrast`; user theme in `~/.config/ditox/themes/foo.toml`.
+- Glyph packs: `ascii` and `unicode`.
+- Layout packs: `default` plus a custom pack testing templates/borders/pager/help/footer.
+
+## Non‑Linux Locking (Important)
+
+- Managed lock refusal on macOS/Windows is deliberate to avoid multiple capture threads touching the same SQLite DB.
+- If you want parity with Linux, add a platform‑specific liveness probe (e.g., `kill(pid, 0)` via nix or `OpenProcess` on Windows) and update `is_pid_alive` accordingly.
+
+---
+
+If you want, I can re‑land any specific section of this spec directly in code with minimal, reviewable commits.


### PR DESCRIPTION
What
- Refine standalone CLI PRD and AGENTS guidelines.
- Expand build/test/lint commands and cautions (clippy invocation). 
- Add full Git worktree workflow and branch naming rules.
- Clarify naming conventions and PR checklist expectations.

Why
- Align docs with actual process and avoid common pitfalls.
- Make it easy for contributors and agents to follow the same playbook.

Scope
- Files: AGENTS.md, standalone-cli-PRD.md
- DB migrations: none
- CLI flags changed: none

Verification
- Doc-only change; no Rust code touched.

Checklist
- [x] Conventional Commit in title
- [x] No schema/data migrations
- [x] No new/changed CLI flags
- [x] Updated docs only